### PR TITLE
Allow CSS purging for production

### DIFF
--- a/build_fns
+++ b/build_fns
@@ -69,7 +69,7 @@ build_ui_source() {
 
     cd "'${APP}'"
     print_info ^^ installing npm deps
-    yarn
+    yarn install --production=false --frozen-lockfile # allows yarn to install devDependencies
 
     print_info ^^ building css
     npx tailwindcss build styles.css -o pkg/styles.css

--- a/build_fns
+++ b/build_fns
@@ -61,6 +61,8 @@ build_image() {
 build_ui_source() {
   local APP=$1
   run_in_docker '
+    export NODE_ENV=production # allows tailwind CSS to purge result CSS from unnecessary classes
+
     print_info() {
       echo -e '\''\033[1;35m'\''$@$'\''\033[0m'\'' # light purple
     }

--- a/ui/README.md
+++ b/ui/README.md
@@ -19,6 +19,10 @@ Node.js stuff
 yarn
 ```
 
+If you set `NODE_ENV=productions` yarn won't install `devDependencies` which are the only dependencies for this project so far.
+
+You can workaround this problem with `yarn --production=false`.
+
 ### Build css
 
 ```sh

--- a/ui/src/components/weights_calculator.rs
+++ b/ui/src/components/weights_calculator.rs
@@ -117,7 +117,7 @@ impl yew::Component for Component {
         <input
           type="text"
           name="tickers"
-          class="h-full w-full border-gray-300 px-2 transition-all border-blue rounded-sm"
+          class="h-full w-full border-gray-300 px-2 transition-all border-blue rounded-sm border"
           onchange=self.link.callback(Msg::TickersInputChanged)
           value={self.picked_tickers.join(" ")}
           autocomplete="off" autocorrect="off" autocapitalize="off"

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,16 +1,11 @@
 .empty input:not(:focus) + label {
-  @apply top-1/2;
-  @apply text-base;
+  @apply top-1/2 text-base;
 }
 input:not(:focus) + label {
   @apply text-gray-500;
 }
-input {
-  @apply border;
-}
 input:focus {
-  @apply outline-none;
-  @apply border-blue-500;
+  @apply outline-none border-blue-500;
 }
 
 @tailwind base;

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  purge: [],
+  purge: [
+    './src/**/*.rs',
+    './index.html',
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {},


### PR DESCRIPTION
Followed https://tailwindcss.com/docs/optimizing-for-production to shrink `styles.css` from `4M` to `14k` uncompressed