### PR TITLE
Using yfinance pandas datareader override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye-slim
 
 RUN apt update &&\
   apt install -y libpython3.9 pip &&\
-  pip install pandas pandas_datareader scipy 
+  pip install pandas numpy datetime scipy pandas_datareader yfinance
 
 COPY release/service /usr/local/bin/service
 COPY rpar.py /usr/local/bin

--- a/rpar.ipynb
+++ b/rpar.ipynb
@@ -2,28 +2,30 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# pip install --user pandas numpy datetime scipy pandas_datareader\n",
+    "# pip install --user pandas numpy datetime scipy pandas_datareader yfinance\n",
     "\n",
     "import pandas as pd\n",
-    "import pandas_datareader.data as web\n",
-    "import numpy as np\n",
     "import datetime\n",
-    "import rpar\n",
-    "import imp\n",
-    "from scipy.optimize import minimize\n",
-    "\n",
-    "TOLERANCE = 1e-10"
+    "import rpar\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[*********************100%***********************]  6 of 6 completed\n"
+     ]
+    }
+   ],
    "source": [
     "# date range used for calculations\n",
     "start_date = datetime.datetime(2018, 4, 17)\n",
@@ -46,25 +48,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "Symbols\n",
-       "MAGN.ME     0.148622\n",
-       "FIVE.ME     0.127462\n",
-       "MTSS.ME     0.198452\n",
-       "MRKP.ME     0.152055\n",
-       "OGKB.ME     0.122496\n",
-       "SNGSP.ME    0.250913\n",
+       "FIVE.ME     0.127455\n",
+       "MAGN.ME     0.148613\n",
+       "MRKP.ME     0.152057\n",
+       "MTSS.ME     0.198454\n",
+       "OGKB.ME     0.122507\n",
+       "SNGSP.ME    0.250915\n",
        "Name: weight, dtype: float64"
       ]
      },
-     "execution_count": 20,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 3
     }
    ],
    "source": [
@@ -230,9 +231,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.7.6 64-bit ('base': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -245,6 +245,9 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.6"
+  },
+  "interpreter": {
+   "hash": "dca0ade3e726a953b501b15e8e990130d2b7799f14cfd9f4271676035ebe5511"
   }
  },
  "nbformat": 4,

--- a/rpar.py
+++ b/rpar.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+import numpy as np
 import pandas as pd
 import pandas_datareader.data as web
-import numpy as np
-import datetime
+import yfinance
 from scipy.optimize import minimize
 
+yfinance.pdr_override()
 TOLERANCE = 1e-10
 
 
@@ -118,7 +119,7 @@ def get_weights(prices):
 
 def get_prices(yahoo_tickers, start_date, end_date):
     return (
-        web.DataReader(yahoo_tickers, 'yahoo',
+        web.DataReader(yahoo_tickers,
                        start_date,
                        end_date
                        )


### PR DESCRIPTION
Yahoo finance quotes loader stopped to work for some reason.

This PR uses more specified lib: https://aroussi.com/post/python-yahoo-finance

Which almost transparently replaces `pandas_datareaded` loaded