### PR TITLE
Fixed ordering in load prices dataframe result

### DIFF
--- a/rpar.ipynb
+++ b/rpar.ipynb
@@ -2,38 +2,34 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 53,
    "source": [
     "# pip install --user pandas numpy datetime scipy pandas_datareader yfinance\n",
     "\n",
     "import pandas as pd\n",
     "import datetime\n",
     "import rpar\n"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[*********************100%***********************]  6 of 6 completed\n"
-     ]
-    }
-   ],
+   "execution_count": 54,
    "source": [
     "# date range used for calculations\n",
     "start_date = datetime.datetime(2018, 4, 17)\n",
-    "end_date = datetime.datetime(2021, 4, 14)\n",
+    "end_date = datetime.datetime(2021, 7, 24)\n",
     "\n",
     "# set up symbols that we like in our portfolio + min trading lot for each symbol\n",
     "yahoo_tickers = ['MAGN.ME','FIVE.ME','MTSS.ME','MRKP.ME','OGKB.ME','SNGSP.ME']\n",
     "min_lots = pd.DataFrame([1, 1, 10, 10000, 1000, 100], yahoo_tickers).T.iloc[0]\n",
+    "\n",
+    "# yahoo_tickers = ['AMZN', 'FB', 'RPAR']\n",
+    "# min_lots = pd.DataFrame([1, 1, 1], yahoo_tickers).T.iloc[0]\n",
+    "\n",
+    "# yahoo_tickers = ['MAGN.ME']\n",
+    "# min_lots = pd.DataFrame([1], yahoo_tickers).T.iloc[0]\n",
     "\n",
     "prices = rpar.get_prices(yahoo_tickers, start_date, end_date)\n",
     "\n",
@@ -44,115 +40,135 @@
     "\n",
     "invested = assets * min_lots * prices.iloc[-1]\n",
     "residual = capital - invested.sum()"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[*********************100%***********************]  6 of 6 completed\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "execution_count": 55,
+   "source": [
+    "weights"
+   ],
    "outputs": [
     {
      "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "FIVE.ME     0.127455\n",
        "MAGN.ME     0.148613\n",
-       "MRKP.ME     0.152057\n",
+       "FIVE.ME     0.127455\n",
        "MTSS.ME     0.198454\n",
+       "MRKP.ME     0.152057\n",
        "OGKB.ME     0.122507\n",
        "SNGSP.ME    0.250915\n",
        "Name: weight, dtype: float64"
       ]
      },
      "metadata": {},
-     "execution_count": 3
+     "execution_count": 55
     }
    ],
-   "source": [
-    "weights"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Symbols\n",
-       "MAGN.ME     688.0\n",
-       "FIVE.ME      16.0\n",
-       "MTSS.ME      18.0\n",
-       "MRKP.ME      18.0\n",
-       "OGKB.ME      46.0\n",
-       "SNGSP.ME     17.0\n",
-       "dtype: float64"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": 56,
    "source": [
     "assets"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "Symbols\n",
-       "MAGN.ME     44551.438110\n",
-       "FIVE.ME     38118.835938\n",
-       "MTSS.ME     56996.998901\n",
-       "MRKP.ME     45377.998352\n",
-       "OGKB.ME     36588.401079\n",
-       "SNGSP.ME    72318.001556\n",
+       "MAGN.ME     714.0\n",
+       "FIVE.ME      15.0\n",
+       "MTSS.ME      20.0\n",
+       "MRKP.ME      19.0\n",
+       "OGKB.ME      50.0\n",
+       "SNGSP.ME     20.0\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 17,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 56
     }
    ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
    "source": [
     "invested"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
-       "6048.326063156128"
+       "MAGN.ME     44545.430008\n",
+       "FIVE.ME     35953.176270\n",
+       "MTSS.ME     58403.460693\n",
+       "MRKP.ME     43556.681573\n",
+       "OGKB.ME     36247.369647\n",
+       "SNGSP.ME    72449.851990\n",
+       "dtype: float64"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 57
     }
    ],
-   "source": [
-    "residual"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 58,
+   "source": [
+    "residual"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "8844.029819011688"
+      ]
+     },
+     "metadata": {},
+     "execution_count": 58
+    }
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "source": [
+    "pd.DataFrame(invested).sort_values(0, ascending=False)"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "                     0\n",
+       "SNGSP.ME  72449.851990\n",
+       "MTSS.ME   58403.460693\n",
+       "MAGN.ME   44545.430008\n",
+       "MRKP.ME   43556.681573\n",
+       "OGKB.ME   36247.369647\n",
+       "FIVE.ME   35953.176270"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -174,59 +190,42 @@
        "      <th></th>\n",
        "      <th>0</th>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>Symbols</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>SNGSP.ME</th>\n",
-       "      <td>72318.001556</td>\n",
+       "      <td>72449.851990</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>MTSS.ME</th>\n",
-       "      <td>56996.998901</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>MRKP.ME</th>\n",
-       "      <td>45377.998352</td>\n",
+       "      <td>58403.460693</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>MAGN.ME</th>\n",
-       "      <td>44551.438110</td>\n",
+       "      <td>44545.430008</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>FIVE.ME</th>\n",
-       "      <td>38118.835938</td>\n",
+       "      <th>MRKP.ME</th>\n",
+       "      <td>43556.681573</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>OGKB.ME</th>\n",
-       "      <td>36588.401079</td>\n",
+       "      <td>36247.369647</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>FIVE.ME</th>\n",
+       "      <td>35953.176270</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                     0\n",
-       "Symbols               \n",
-       "SNGSP.ME  72318.001556\n",
-       "MTSS.ME   56996.998901\n",
-       "MRKP.ME   45377.998352\n",
-       "MAGN.ME   44551.438110\n",
-       "FIVE.ME   38118.835938\n",
-       "OGKB.ME   36588.401079"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 59
     }
    ],
-   "source": [
-    "pd.DataFrame(invested).sort_values(0, ascending=False)"
-   ]
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/rpar.py
+++ b/rpar.py
@@ -118,16 +118,24 @@ def get_weights(prices):
 
 
 def get_prices(yahoo_tickers, start_date, end_date):
-    return (
-        web.DataReader(yahoo_tickers,
+  prices = (web.DataReader(yahoo_tickers,
                        start_date,
                        end_date
                        )
-        .loc[:, 'Adj Close']
-        .asfreq('B')  # align time series to business days
-        .ffill()      # forward fill missing (NaN) data
-    )
+    .loc[:, 'Adj Close']
+    .asfreq('B')  # align time series to business days
+    .ffill()      # forward fill missing (NaN) data
+  )
 
+  # fix some of yfinance price loading results caveats
+  if len(yahoo_tickers) > 1:
+    values = {}
+    for ticker in yahoo_tickers:
+      values[ticker] = prices[ticker].values
+
+    return pd.DataFrame(values, index=prices.index)
+  else:
+    return pd.DataFrame({yahoo_tickers[0]: prices.values}, index=prices.index)
 
 def find_tickers_with_missing_data(prices):
     result = []


### PR DESCRIPTION
After switching to `yfinance` results is a mess:
1) it doesn't work with a single ticker
2) it returns prices columns in a random order this likely leads to wrong results